### PR TITLE
Update setup-php action to 2.37.1

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: '8.4'
 


### PR DESCRIPTION
Updated shivammathur/setup-php action for security update.
- https://github.com/shivammathur/setup-php/releases/tag/2.37.1